### PR TITLE
strip out leading '=' and 'v' from version for consideration

### DIFF
--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -277,6 +277,7 @@ def test_prerelease_2():
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(0 == len(subset))
 
+
 def test_prerelease_3():
     mask = 'L.Y.Y-Y'
     versions = ['0.9.5', '1.0.0-alpha.e2', '1.0.0-alpha.12', '1.0.0-alpha.58', '0.9.6-alpha.ef']
@@ -285,6 +286,7 @@ def test_prerelease_3():
     assert(1 == len(subset))
     assert('0.9.6-alpha.ef' in subset)
 
+
 def test_prerelease_4():
     mask = 'L.Y.Y'
     versions = ['0.9.5', '1.0.0-alpha.e2', '1.0.0-alpha.12', '1.0.0-alpha.58', '0.9.6', '1.0.0']
@@ -292,6 +294,7 @@ def test_prerelease_4():
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(1 == len(subset))
     assert('0.9.6' in subset)
+
 
 def test_prerelease_5():
     mask = 'Y.Y.Y'
@@ -302,8 +305,53 @@ def test_prerelease_5():
     assert('0.9.6' in subset)
     assert('1.0.0' in subset)
 
+
 def test_prerelease_6():
     mask = 'Y.Y.Y-Y'
     versions = ['0.9.5', '1.0.0-alpha.e2', '1.0.0-alpha.12', '1.0.0-alpha.58', '0.9.6', '1.0.0']
     subset = VersionFilter.semver_filter(mask, versions)
     assert(6 == len(subset))
+
+
+def test_v_prefix_on_versions():
+    mask = 'L.L.Y'
+    versions = ['v0.9.5', 'v0.9.6', 'v1.0.0']
+    current_version = '0.9.5'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('v0.9.6' in subset)
+
+
+def test_v_prefix_on_current_version():
+    mask = 'L.L.Y'
+    versions = ['0.9.5', '0.9.6', '1.0.0']
+    current_version = 'v0.9.5'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('0.9.6' in subset)
+
+
+def test_eq_prefix_on_versions():
+    mask = 'L.L.Y'
+    versions = ['=0.9.5', '=0.9.6', '=1.0.0']
+    current_version = '0.9.5'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('=0.9.6' in subset)
+
+
+def test_eq_prefix_on_current_version():
+    mask = 'L.L.Y'
+    versions = ['0.9.5', '0.9.6', '1.0.0']
+    current_version = '=0.9.5'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('0.9.6' in subset)
+
+
+def test_v_and_eq_prefix_on_current_version():
+    mask = 'L.L.Y'
+    versions = ['0.9.5', '0.9.6', '1.0.0']
+    current_version = 'v=0.9.5'
+    with pytest.raises(ValueError):
+        VersionFilter.semver_filter(mask, versions, current_version)

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -5,8 +5,8 @@ import semantic_version
 
 class VersionFilter(object):
 
-    @classmethod
-    def semver_filter(cls, mask, versions, current_version=None):
+    @staticmethod
+    def semver_filter(mask, versions, current_version=None):
         """Return a list of versions that are greater than the current version and that match the mask"""
         current = _parse_semver(current_version) if current_version else None
         _mask = SpecMask(mask, current)
@@ -25,8 +25,8 @@ class VersionFilter(object):
 
         return [v.original_string for v in selected_versions]
 
-    @classmethod
-    def regex_filter(cls, regex_str, versions):
+    @staticmethod
+    def regex_filter(regex_str, versions):
         """Return a list of versions that match the given regular expression."""
         regex = re.compile(regex_str)
         return [v for v in versions if regex.search(v)]

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -5,8 +5,8 @@ import semantic_version
 
 class VersionFilter(object):
 
-    @staticmethod
-    def semver_filter(mask, versions, current_version=None):
+    @classmethod
+    def semver_filter(cls, mask, versions, current_version=None):
         """Return a list of versions that are greater than the current version and that match the mask"""
         current = _parse_semver(current_version) if current_version else None
         _mask = SpecMask(mask, current)
@@ -25,8 +25,8 @@ class VersionFilter(object):
 
         return [v.original_string for v in selected_versions]
 
-    @staticmethod
-    def regex_filter(regex_str, versions):
+    @classmethod
+    def regex_filter(cls, regex_str, versions):
         """Return a list of versions that match the given regular expression."""
         regex = re.compile(regex_str)
         return [v for v in versions if regex.search(v)]
@@ -250,5 +250,7 @@ def _parse_semver(version):
     if isinstance(version, semantic_version.Version):
         return version
     if isinstance(version, str):
-        return semantic_version.Version.coerce(version)
+        # strip leading 'v' and '=' chars
+        cleaned = version[1:] if version.startswith('=') or version.startswith('v') else version
+        return semantic_version.Version.coerce(cleaned)
     raise ValueError('version must be either a str or a Version object')


### PR DESCRIPTION
@davegaeddert Are these tests asserting the behavior you would expect?  I *think* it is the right decision to always return the original version strings that we given and not the cleaned versions, right?

This will close issue #5 