### PR TITLE
[WIP] Handle python versioning syntax

### DIFF
--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -218,6 +218,15 @@ def test_explicit_major_updates_only_1():
     assert('2.0.0' in subset)
 
 
+def test_python_filter():
+    mask = 'Y.Y.Y'
+    versions = ['0.1.0', '1.1.0', '1.2.1.dev0', '1.2.dev0', '1.2.post0', '1.2.0a1']
+    subset = VersionFilter.semver_filter(mask, versions)
+    assert(2 == len(subset))
+    assert('0.1.0' in subset)
+    assert('1.1.0' in subset)
+
+
 def test_django_config_example_1():
     mask = '1.8.Y'
     versions = ['1.8.0', '1.8.1', '1.8.2', '1.9.0', '1.9.1', '1.10.0', '2.0.0', '2.0.1']

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -2,6 +2,7 @@ import pytest
 
 from version_filter import VersionFilter
 from version_filter import SpecItemMask, SpecMask
+from version_filter.version_filter import _parse_semver, InvalidSemverError
 from semantic_version import Version, Spec
 
 
@@ -365,3 +366,15 @@ def test_v_and_eq_prefix_on_current_version():
     current_version = 'v=0.9.5'
     with pytest.raises(ValueError):
         VersionFilter.semver_filter(mask, versions, current_version)
+
+
+def test_valid_version_parsing_1():
+    assert(Version('0.0.1') == _parse_semver('0.0.1'))
+    assert(Version('0.0.1-dev0') == _parse_semver('0.0.1-dev0'))
+    assert(Version('0.0.1-dev0.build0') == _parse_semver('0.0.1-dev0.build0'))
+    assert(Version('0.0.1+something') == _parse_semver('0.0.1+something'))
+
+
+def test_invalid_version_parsing_1():
+    with pytest.raises(InvalidSemverError):
+        _parse_semver('0.0.1.build0')  # invalid build string

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -258,8 +258,11 @@ def _parse_semver(version):
     if isinstance(version, str):
         # strip leading 'v' and '=' chars
         cleaned = version[1:] if version.startswith('=') or version.startswith('v') else version
-        v = semantic_version.Version.coerce(cleaned)
-        if len(v.build) > 0:
-            raise InvalidSemverError('build fields should not be used')
+        try:
+            v = semantic_version.Version(cleaned)
+        except ValueError:
+            v = semantic_version.Version.coerce(cleaned)
+            if len(v.build) > 0:
+                raise InvalidSemverError('build fields should not be used')
         return v
     raise ValueError('version must be either a str or a Version object')

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -3,6 +3,10 @@ import re
 import semantic_version
 
 
+class InvalidSemverError(ValueError):
+    pass
+
+
 class VersionFilter(object):
 
     @staticmethod
@@ -16,6 +20,8 @@ class VersionFilter(object):
             try:
                 v = _parse_semver(version)
                 v.original_string = version
+            except InvalidSemverError:
+                continue  # skip invalid semver strings
             except ValueError:
                 continue  # skip invalid semver strings
             _versions.append(v)
@@ -252,5 +258,8 @@ def _parse_semver(version):
     if isinstance(version, str):
         # strip leading 'v' and '=' chars
         cleaned = version[1:] if version.startswith('=') or version.startswith('v') else version
-        return semantic_version.Version.coerce(cleaned)
+        v = semantic_version.Version.coerce(cleaned)
+        if len(v.build) > 0:
+            raise InvalidSemverError('build fields should not be used')
+        return v
     raise ValueError('version must be either a str or a Version object')


### PR DESCRIPTION
@paulortman I'm not sure what we want to do here. The test explains it but basically a python library using `1.1.0.devN` gets coerced into `1.1.0+devN` as build metadata, and then build metadata is matched by the filter. What I would have expected to happen for now is for those `.dev` versions to simply be skipped as invalid semver (not a positive integer for patch)...

https://github.com/rbarrois/python-semanticversion/blob/master/semantic_version/base.py#L114
https://www.python.org/dev/peps/pep-0440/

I think we started using their `coerce` to fill out the zeros? Do we want to do that ourselves and then not coerce? Or does their `partial` work for us somehow here? Other thoughts?