### PR TITLE
Pre-release matching and locking

### DIFF
--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -351,6 +351,15 @@ def test_prerelease_lock():
     assert('3.6.1-alpine' in subset)
 
 
+def test_prerelease_lock_2():
+    mask = 'L.L.Y-L'
+    versions = ['3.6', '3.6-alpine', '3.6-alpine3.6', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6', '3.6.1-onbuild']
+    current_version = '3.6-alpine3.6'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('3.6.1-alpine3.6' in subset)
+
+
 def test_v_prefix_on_versions():
     mask = 'L.L.Y'
     versions = ['v0.9.5', 'v0.9.6', 'v1.0.0']

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -121,7 +121,7 @@ def test_partial_versions_3():
     mask = 'L'
     current_version = '1'
     s = SpecItemMask(mask, current_version)
-    assert(s.spec == Spec('1'))
+    assert(s.spec == Spec('==1.0.0'))
 
 
 def test_partial_versions_4():
@@ -322,6 +322,24 @@ def test_prerelease_6():
     versions = ['0.9.5', '1.0.0-alpha.e2', '1.0.0-alpha.12', '1.0.0-alpha.58', '0.9.6', '1.0.0']
     subset = VersionFilter.semver_filter(mask, versions)
     assert(6 == len(subset))
+
+
+def test_prerelease_matching():
+    mask = 'L.L.Y-alpine'
+    versions = ['3.6', '3.6-alpine', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6', '3.6.1-onbuild']
+    current_version = '3.6-alpine'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('3.6.1-alpine' in subset)
+
+
+def test_prerelease_matching_2():
+    mask = 'L.L.Y-alpine3.6'
+    versions = ['3.6', '3.6-alpine', '3.6-alpine3.6', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6', '3.6.1-onbuild']
+    current_version = '3.6-alpine3.6'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('3.6.1-alpine3.6' in subset)
 
 
 def test_v_prefix_on_versions():

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -342,6 +342,15 @@ def test_prerelease_matching_2():
     assert('3.6.1-alpine3.6' in subset)
 
 
+def test_prerelease_lock():
+    mask = 'L.L.Y-L'
+    versions = ['3.6', '3.6-alpine', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6', '3.6.1-onbuild']
+    current_version = '3.6-alpine'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('3.6.1-alpine' in subset)
+
+
 def test_v_prefix_on_versions():
     mask = 'L.L.Y'
     versions = ['v0.9.5', 'v0.9.6', 'v1.0.0']

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -79,19 +79,17 @@ class SpecItemMask(object):
 
             # Use _parse_semver but temporarily replace L and Y to be valid
             # this is a bit hacky...
-            temp_version = version[:]
             lock_placeholder = '9999990'
             yes_placeholder = '9999991'
-            temp_version = temp_version.replace(self.LOCK, lock_placeholder).replace(self.YES, yes_placeholder)
-            v = _parse_semver(str(temp_version))
+            parseable_version = version.replace(self.LOCK, lock_placeholder).replace(self.YES, yes_placeholder)
+            v = _parse_semver(str(parseable_version))
 
             # Substitute the current version integers for LOCKs
-            lock_placeholder_int = int(lock_placeholder)
-            if v.major == lock_placeholder_int:
+            if v.major == int(lock_placeholder):
                 v.major = self.current_version.major
-            if v.minor == lock_placeholder_int:
+            if v.minor == int(lock_placeholder):
                 v.minor = self.current_version.minor
-            if v.patch == lock_placeholder_int:
+            if v.patch == int(lock_placeholder):
                 v.patch = self.current_version.patch
             if v.prerelease and v.prerelease[0] == lock_placeholder:
                 # prerelease is a tuple of strings


### PR DESCRIPTION
@paulortman can you look over this at some point? It adds "L" for pre-releases and also allows for matching prerelease by string, which I don't think worked before. I did a bit of a dirty thing though by re-using `_parse_semver` (after replacing "L" and "Y" with bogus ints) to do the parsing, instead of just splitting on "." which can have issues since pre-releases (and builds) can have "." in them.