### PR TITLE
Test caret specifier behavior

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-semantic_version==2.6.0
+-e git+https://github.com/paulortman/python-semanticversion.git@b25e541591d020048316dace0f7c01d0a3262592#egg=python-semanticversion

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -404,6 +404,25 @@ def test_v_and_eq_prefix_on_current_version():
         VersionFilter.semver_filter(mask, versions, current_version)
 
 
+def test_caret():
+    mask = '^1.0.0'
+    versions = ['1.0.0', '1.0.1', '1.1.0', '1.2.0-alpha', '2.0.0', '2.0.0-beta']
+    current_version = '1.0.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(2 == len(subset))
+    assert('1.0.1' in subset)
+    assert('1.1.0' in subset)
+
+
+def test_semver_caret():
+    spec = Spec('^1.0.0')
+    assert(Version('1.1.0') in spec)
+    assert(Version('1.1.0-alpha') not in spec)  # fails
+
+    assert(Version('2.0.0') not in spec)
+    assert(Version('2.0.0-alpha') not in spec)  # fails
+
+
 def test_valid_version_parsing_1():
     assert(Version('0.0.1') == _parse_semver('0.0.1'))
     assert(Version('0.0.1-dev0') == _parse_semver('0.0.1-dev0'))

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -439,10 +439,10 @@ def test_caret_babel_cli_example():
 def test_semver_caret():
     spec = Spec('^1.0.0')
     assert(Version('1.1.0') in spec)
-    assert(Version('1.1.0-alpha') not in spec)  # fails
+    assert(Version('1.1.0-alpha') not in spec)
 
     assert(Version('2.0.0') not in spec)
-    assert(Version('2.0.0-alpha') not in spec)  # fails
+    assert(Version('2.0.0-alpha') not in spec)
 
 
 def test_valid_version_parsing_1():

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -414,6 +414,28 @@ def test_caret():
     assert('1.1.0' in subset)
 
 
+def test_caret_babel_cli_example():
+    mask = '^L.L.L'
+    versions = [
+        '6.24.0',
+        '7.0.0-alpha.3',
+        '7.0.0-alpha.4',
+        '7.0.0-alpha.6',
+        '7.0.0-alpha.7',
+        '6.24.1',
+        '7.0.0-alpha.8',
+        '7.0.0-alpha.9',
+        '7.0.0-alpha.10',
+        '7.0.0-alpha.11',
+        '7.0.0-alpha.12',
+        '7.0.0-alpha.14',
+    ]
+    current_version = '6.24.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('6.24.1' in subset)
+
+
 def test_semver_caret():
     spec = Spec('^1.0.0')
     assert(Version('1.1.0') in spec)


### PR DESCRIPTION
@paulortman this does not work how I expected it to...what do you think? Looks like it's the behavior of the underlying library. I would have expected prereleases not to be included.

https://github.com/rbarrois/python-semanticversion/blob/master/tests/test_base.py#L505

Related? https://github.com/rbarrois/python-semanticversion/issues/42

![image](https://user-images.githubusercontent.com/649496/32207273-c6bada98-bdc8-11e7-90fd-1c282f346b0f.png)
