### PR TITLE
Fuzzy Next Matching

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.6.0 (unreleased)
 ------------------
 
-- Enable the "Fuzzy Next" matching algorithm to find next best releases when anticipated releases do not exist
+- Enable the "Next Best" matching algorithm to find next best releases when anticipated releases do not exist
 
 
 0.5.1 (2017-12-09)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,10 @@
 History
 =======
 
-0.5.2 (unreleased)
+0.6.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enable the "Fuzzy Next" matching algorithm to find next best releases when anticipated releases do not exist
 
 
 0.5.1 (2017-12-09)

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,17 @@ Mask Yes Extension
 Yes (``Y``) are used to provide wildcard acceptance of any value in the position of the ``Y``.  It can be used in the
 major, minor, patch or pre-release components of version'
 
+'Fuzzy Next' Matching Extension
+...............................
+
+Some packages fail to ever publicly release expected semantic version.  Take for instance a package that never releases
+a ``'2.0.0'`` version, but instead has ``'2.0.1'`` as the first available version of the 2 series.  To be able to handle
+that convention deviation without resorting to ranges or wildcards and thus losing some of the power of the Lock and Yes
+extensions you can prefix a mask with the hyphen (``-``) character.  This allows the algorithm to anticipate what
+releases "should" get released, and select the "next" release if the anticipated release never appears.  For instance,
+the mask ``'-Y.0.0'`` anticipates that the ``'2.0.0'`` release will be made, but will return the ``2.0.1`` if the
+``2.0.0`` release never appears.
+
 Boolean AND and OR
 ..................
 
@@ -57,6 +68,8 @@ Some common examples:
 * ``'1.Y.0'`` # return only those minor versions that are of major release 1
 * ``'L.Y.0'`` # return only those minor versions that are greater than the currently installed version, but in the same
   major release
+* ``'-Y.0.0'`` # return only major versions that are greater than the currently installed version with "fuzzy next"
+  matching enabled (will return a 2.0.1 release if 2.0.0 is never released)
 * ``'L.L.Y'`` # return only those patch versions that are greater than the currently installed version, but in the same
   major and minor release
 * ``'Y.Y.Y'`` # return all major, minor and patch versions

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ major, minor, patch or pre-release components of version'
 'Next Best' Matching Extension
 ...............................
 
-Some packages fail to ever publicly release expected semantic version.  Take for instance a package that never releases
+Some packages fail to ever publicly release expected semantic versions.  Take for instance a package that never releases
 a ``'2.0.0'`` version, but instead has ``'2.0.1'`` as the first available version of the 2 series.  To be able to handle
 that convention deviation without resorting to ranges or wildcards and thus losing some of the power of the Lock and Yes
 extensions you can prefix a mask with the hyphen (``-``) character.  This allows the algorithm to anticipate what

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Mask Yes Extension
 Yes (``Y``) are used to provide wildcard acceptance of any value in the position of the ``Y``.  It can be used in the
 major, minor, patch or pre-release components of version'
 
-'Fuzzy Next' Matching Extension
+'Next Best' Matching Extension
 ...............................
 
 Some packages fail to ever publicly release expected semantic version.  Take for instance a package that never releases
@@ -68,7 +68,7 @@ Some common examples:
 * ``'1.Y.0'`` # return only those minor versions that are of major release 1
 * ``'L.Y.0'`` # return only those minor versions that are greater than the currently installed version, but in the same
   major release
-* ``'-Y.0.0'`` # return only major versions that are greater than the currently installed version with "fuzzy next"
+* ``'-Y.0.0'`` # return only major versions that are greater than the currently installed version with "next best"
   matching enabled (will return a 2.0.1 release if 2.0.0 is never released)
 * ``'L.L.Y'`` # return only those patch versions that are greater than the currently installed version, but in the same
   major and minor release

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+future
 -e git+https://github.com/paulortman/python-semanticversion.git@b25e541591d020048316dace0f7c01d0a3262592#egg=python-semanticversion

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -678,3 +678,11 @@ def test_fuzzy_next_specitemmask_with_range_1():
     ]
     with pytest.raises(ValueError):
         VersionFilter.semver_filter(mask, versions)
+
+
+def test_fuzzy_example():
+    versions = ['1.0.0', '2.0.0', '3.0.1']
+    current_version = '2.0.0'
+    assert VersionFilter.semver_filter('Y.0.0', versions, current_version) == []
+    # but with fuzzy ...
+    assert VersionFilter.semver_filter('-Y.0.0', versions, current_version) == ['3.0.1']

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -455,3 +455,77 @@ def test_valid_version_parsing_1():
 def test_invalid_version_parsing_1():
     with pytest.raises(InvalidSemverError):
         _parse_semver('0.0.1.build0')  # invalid build string
+
+
+def test_fuzzy_next_specitemmask():
+    s = SpecItemMask('-1.0.0')
+    assert(Spec('1.0.0') == s.spec)
+    assert(s.has_fuzzy_next)
+
+
+def test_fuzzy_next_specitemmask_matching_versions_literal1():
+    mask = '-1.0.0'
+    versions = [
+        '1.0.1',
+        '2.0.1',
+    ]
+    subset = VersionFilter.semver_filter(mask, versions)
+    assert(1 == len(subset))
+    assert('1.0.1' in subset)
+
+
+def test_fuzzy_next_specitemmask_matching_versions_literal2():
+    mask = '-1.0.0'
+    versions = [
+        '1.1.0',
+        '2.0.1',
+    ]
+    subset = VersionFilter.semver_filter(mask, versions)
+    assert(1 == len(subset))
+    assert('1.1.0' in subset)
+
+
+def test_fuzzy_next_specitemmask_matching_versions_literal3():
+    mask = '-1.0.0'
+    versions = [
+        '1.0.0',
+        '2.0.1',
+    ]
+    subset = VersionFilter.semver_filter(mask, versions)
+    assert(0 == len(subset))
+
+
+def test_fuzzy_next_specitemmask_matching_versions_lock1():
+    mask = '-L.0.0'
+    versions = [
+        '1.0.1',
+        '2.0.1',
+    ]
+    current_version = '1.0.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('1.0.1' in subset)
+
+
+def test_fuzzy_next_specitemmask_matching_versions_lock2():
+    mask = '-L.0.0'
+    versions = [
+        '1.1.0',
+        '2.0.1',
+    ]
+    current_version = '1.0.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('1.1.0' in subset)
+
+
+def test_fuzzy_next_specitemmask_matching_versions_lock3():
+    mask = '-L.0.0'
+    versions = [
+        '1.0.0',
+        '2.0.1',
+    ]
+    current_version = '1.0.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(0 == len(subset))
+

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -458,13 +458,13 @@ def test_invalid_version_parsing_1():
         _parse_semver('0.0.1.build0')  # invalid build string
 
 
-def test_fuzzy_next_specitemmask():
+def test_next_best_specitemmask():
     s = SpecItemMask('-1.0.0')
     assert(Spec('1.0.0') == s.spec)
-    assert s.has_fuzzy_next
+    assert s.has_next_best
 
 
-def test_fuzzy_next_specitemmask_matching_versions_literal1():
+def test_next_best_specitemmask_matching_versions_literal1():
     mask = '-1.0.0'
     versions = [
         '1.0.1',
@@ -475,7 +475,7 @@ def test_fuzzy_next_specitemmask_matching_versions_literal1():
     assert('1.0.1' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_literal2():
+def test_next_best_specitemmask_matching_versions_literal2():
     mask = '-1.0.0'
     versions = [
         '1.1.0',
@@ -486,7 +486,7 @@ def test_fuzzy_next_specitemmask_matching_versions_literal2():
     assert('1.1.0' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_literal3():
+def test_next_best_specitemmask_matching_versions_literal3():
     mask = '-1.0.0'
     versions = [
         '1.0.0',
@@ -496,7 +496,7 @@ def test_fuzzy_next_specitemmask_matching_versions_literal3():
     assert(0 == len(subset))
 
 
-def test_fuzzy_next_specitemmask_matching_versions_lock1():
+def test_next_best_specitemmask_matching_versions_lock1():
     mask = '-L.0.0'
     versions = [
         '1.0.1',
@@ -508,7 +508,7 @@ def test_fuzzy_next_specitemmask_matching_versions_lock1():
     assert('1.0.1' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_lock2():
+def test_next_best_specitemmask_matching_versions_lock2():
     mask = '-L.0.0'
     versions = [
         '1.1.0',
@@ -520,7 +520,7 @@ def test_fuzzy_next_specitemmask_matching_versions_lock2():
     assert('1.1.0' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_lock3():
+def test_next_best_specitemmask_matching_versions_lock3():
     mask = '-L.0.0'
     versions = [
         '1.0.0',
@@ -531,7 +531,7 @@ def test_fuzzy_next_specitemmask_matching_versions_lock3():
     assert(0 == len(subset))
 
 
-def test_get_fake_fuzzy_versions1():
+def test_get_next_best_versions1():
     y = YesVersion('Y.0.0')
     versions = [
         '1.0.0',
@@ -541,12 +541,12 @@ def test_get_fake_fuzzy_versions1():
     ]
     versions = [_parse_semver(x) for x in versions]
 
-    result = y.get_fake_fuzzy_versions(versions)
+    result = y.get_next_best_versions(versions)
     assert(1 == len(result))
     assert(_parse_semver('2.0.0') in result)
 
 
-def test_get_fake_fuzzy_versions2():
+def test_get_next_best_versions2():
     y = YesVersion('Y.Y.0')
     versions = [
         '1.0.0',
@@ -557,14 +557,14 @@ def test_get_fake_fuzzy_versions2():
     ]
     versions = [_parse_semver(x) for x in versions]
 
-    result = y.get_fake_fuzzy_versions(versions)
+    result = y.get_next_best_versions(versions)
     assert(3 == len(result))
     assert(_parse_semver('1.1.0') in result)
     assert(_parse_semver('2.0.0') in result)
     assert(_parse_semver('2.1.0') in result)
 
 
-def test_get_fake_fuzzy_versions3():
+def test_get_next_best_versions3():
     y = YesVersion('1.0.0')
     versions = [
         '1.0.0',
@@ -575,11 +575,11 @@ def test_get_fake_fuzzy_versions3():
     ]
     versions = [_parse_semver(x) for x in versions]
 
-    result = y.get_fake_fuzzy_versions(versions)
+    result = y.get_next_best_versions(versions)
     assert(0 == len(result))
 
 
-def test_get_fake_fuzzy_versions4():
+def test_get_next_best_versions4():
     y = YesVersion('Y.Y.Y')
     versions = [
         '1.0.0',
@@ -591,14 +591,14 @@ def test_get_fake_fuzzy_versions4():
     ]
     versions = [_parse_semver(x) for x in versions]
 
-    result = y.get_fake_fuzzy_versions(versions)
+    result = y.get_next_best_versions(versions)
     assert(3 == len(result))
     assert(_parse_semver('1.0.2') in result)
     assert(_parse_semver('1.0.3') in result)
     assert(_parse_semver('1.0.4') in result)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_yes1():
+def test_next_best_specitemmask_matching_versions_yes1():
     mask = '-Y.0.0'
     versions = [
         '1.0.1',
@@ -611,7 +611,7 @@ def test_fuzzy_next_specitemmask_matching_versions_yes1():
     assert('2.0.1' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_yes2():
+def test_next_best_specitemmask_matching_versions_yes2():
     mask = '-Y.0.0'
     versions = [
         '1.1.0',
@@ -628,7 +628,7 @@ def test_fuzzy_next_specitemmask_matching_versions_yes2():
     assert('3.1.2' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_yes3():
+def test_next_best_specitemmask_matching_versions_yes3():
     mask = '-Y.0.0'
     versions = [
         '1.0.0',
@@ -640,7 +640,7 @@ def test_fuzzy_next_specitemmask_matching_versions_yes3():
     assert('2.0.1' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_yes4():
+def test_next_best_specitemmask_matching_versions_yes4():
     mask = '-Y.Y.0'
     versions = [
         '1.0.0',
@@ -656,7 +656,7 @@ def test_fuzzy_next_specitemmask_matching_versions_yes4():
     assert('2.0.1' in subset)
 
 
-def test_fuzzy_next_specitemmask_matching_versions_yes5():
+def test_next_best_specitemmask_matching_versions_yes5():
     mask = '-Y.0.0'
     versions = [
         '1.0.0',
@@ -671,8 +671,8 @@ def test_fuzzy_next_specitemmask_matching_versions_yes5():
     assert('2.0.1' in subset)
 
 
-def test_fuzzy_next_specitemmask_with_range_1():
-    """Mixing semver range operators and fuzzy matching is not allowed"""
+def test_next_best_specitemmask_with_range_1():
+    """Mixing semver range operators and next_best matching is not allowed"""
     mask = '-^1.0.0'
     versions = [
         '1.0.0',
@@ -681,9 +681,9 @@ def test_fuzzy_next_specitemmask_with_range_1():
         VersionFilter.semver_filter(mask, versions)
 
 
-def test_fuzzy_example():
+def test_next_best_example():
     versions = ['1.0.0', '2.0.0', '3.0.1']
     current_version = '2.0.0'
     assert VersionFilter.semver_filter('Y.0.0', versions, current_version) == []
-    # but with fuzzy ...
+    # but with next_best ...
     assert VersionFilter.semver_filter('-Y.0.0', versions, current_version) == ['3.0.1']

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 
 from version_filter import VersionFilter

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -124,14 +124,20 @@ class SpecItemMask(object):
         if not self.has_fuzzy_next:
             return [v for v in versions if v in self]
         else:
-            return []
-            fabricated_versions = self.fabricate_versions(versions)
+            return self.fuzzy_matches(versions)
 
-    def fabricate_versions(self, versions):
-        # majors = set([v.major for v in versions])
-        # minors = set([v.minor for v in versions])
-        # patches = set([v.patch for v in versions])
-        pass
+    def fuzzy_matches(self, versions):
+        fake_version = _parse_semver(str(self.version))
+        fake_version.is_fake = True
+        if fake_version not in versions:
+            versions.add(fake_version)
+
+        versions = sorted(versions)
+        matched_versions = []
+        for i, v in enumerate(versions):
+            if hasattr(v, 'is_fake') and ((i + 1) < len(versions)):
+                matched_versions.append(versions[i + 1])
+        return matched_versions
 
     def __contains__(self, item):
         return self.match(item)

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -382,7 +382,9 @@ class YesVersion(object):
 
 def _parse_semver(version, makefake=False):
     if isinstance(version, semantic_version.Version):
-        return _make_fake_version(version) if makefake else version
+        if makefake:
+            version.is_fake = True
+        return version
     if isinstance(version, str):
         # strip leading 'v' and '=' chars
         cleaned = version[1:] if version.startswith('=') or version.startswith('v') else version
@@ -393,10 +395,7 @@ def _parse_semver(version, makefake=False):
             if len(v.build) > 0:
                 raise InvalidSemverError('build fields should not be used')
         v.original_string = version
-        return _make_fake_version(v) if makefake else v
+        if makefake:
+            v.is_fake = True
+        return v
     raise ValueError('version must be either a str or a Version object')
-
-
-def _make_fake_version(version):
-    version.is_fake = True
-    return version

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import str
 import re
 import semantic_version
 

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -135,7 +135,6 @@ class SpecMask(object):
         self.specs = [SpecItemMask(s, self.current_version) for s in self.specs]
 
     def match(self, version):
-        # Todo: save the original string version to return untouched
         v = _parse_semver(version)
 
         # We implicitly require that SpecMasks disregard releases older than the current_version if it is specified
@@ -155,7 +154,6 @@ class SpecMask(object):
         for i, version in enumerate(versions):
             try:
                 v = _parse_semver(version)
-                v.original_string = version
                 valid_versions.append(v)
             except InvalidSemverError:
                 continue  # skip invalid semver strings
@@ -282,5 +280,6 @@ def _parse_semver(version):
             v = semantic_version.Version.coerce(cleaned)
             if len(v.build) > 0:
                 raise InvalidSemverError('build fields should not be used')
+        v.original_string = version
         return v
     raise ValueError('version must be either a str or a Version object')

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -110,6 +110,10 @@ class SpecItemMask(object):
         self.handle_lock_parsing()
         self.handle_yes_parsing()
 
+        if self.has_next_best and self.kind not in ['', '*']:
+            raise ValueError('SpecItem {} operator kind needs to be "" or "*", was "{}". '.format(self, self.kind) +
+                             'Unable to use a next_best match mode')
+
     def match(self, version):
         spec_match = version in self.spec and version in self.newer_than_current()
         if self.has_next_best:
@@ -134,9 +138,6 @@ class SpecItemMask(object):
             return [v for v in self.next_best_matches(versions) if v in self.newer_than_current()]
 
     def next_best_matches(self, versions):
-        if self.kind not in ['', '*']:
-            raise ValueError('SpecItem {} operator kind needs to be "" or "*", was "{}". '.format(self, self.kind) +
-                             'Unable to use a next_best match mode')
         if not self.has_yes:
             # specs with a lock or hard coded numbers can only result in a single fake version
             fake_version = _parse_semver(str(self.version), makefake=True)


### PR DESCRIPTION
Addresses #15 by adding a "fuzzy" matching algorithm.  Adding a hyphen to the beginning of the mask kicks off this mode.  It is currently compatible with masks containing numbers, "locks" and "yeses".  Interactions with other SemVer range operators (^, ~, ...) are currently unimplemented.

The primary use case is to find the versions where the expected next major or minor version is not released.
```python
def test_fuzzy_example():
    versions = ['1.0.0', '2.0.0', '3.0.1']
    current_version = '2.0.0'
    assert VersionFilter.semver_filter('Y.0.0', versions, current_version) == []
    # but with fuzzy ...
    assert VersionFilter.semver_filter('-Y.0.0', versions, current_version) == ['3.0.1']
```