### PR TITLE
Add support for lock-plus-n syntax in masks

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,10 @@
 History
 =======
 
-0.6.1 (unreleased)
+0.7.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for "Last + N" matching in masks
 
 
 0.6.0 (2018-01-08)

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,9 @@ Mask Lock Extension
 
 Locks (``L``) are used as a substitution character in the mask for the major, minor and patch components where you want
 to limit the version filter to just those versions where it has the same value as the given current_version.  If a ``L``
-is present anywhere in the mask, a current_version parameter must also be provided.
+is present anywhere in the mask, a current_version parameter must also be provided.  By giving a positive integer
+immediately following the 'L' you can express "lock + int" behavior.  For example, ``L1`` in a mask states "the current
+version number + 1" for any given position.
 
 Mask Yes Extension
 ..................
@@ -68,6 +70,8 @@ Some common examples:
 * ``'1.Y.0'`` # return only those minor versions that are of major release 1
 * ``'L.Y.0'`` # return only those minor versions that are greater than the currently installed version, but in the same
   major release
+* ``'>=L1.0.0'`` # return every minor and patch version for major versions at least 1 greater that the current major
+  version
 * ``'-Y.0.0'`` # return only major versions that are greater than the currently installed version with "next best"
   matching enabled (will return a 2.0.1 release if 2.0.0 is never released)
 * ``'L.L.Y'`` # return only those patch versions that are greater than the currently installed version, but in the same

--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,7 @@ Some common examples:
 * ``'1.Y.0'`` # return only those minor versions that are of major release 1
 * ``'L.Y.0'`` # return only those minor versions that are greater than the currently installed version, but in the same
   major release
-* ``'>=L1.0.0'`` # return every minor and patch version for major versions at least 1 greater that the current major
-  version
+* ``'>=L1.0.0'`` # return every version for major versions at least 1 greater that the current major version
 * ``'-Y.0.0'`` # return only major versions that are greater than the currently installed version with "next best"
   matching enabled (will return a 2.0.1 release if 2.0.0 is never released)
 * ``'L.L.Y'`` # return only those patch versions that are greater than the currently installed version, but in the same

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -38,9 +38,11 @@ def test_specitemmask_lock5():
     s = SpecItemMask('L1.L999.L', current_version=Version('1.8.3'))
     assert(Spec('2.1007.3') == s.spec)
 
+
 def test_specitemmask_lock6():
     with pytest.raises(ValueError):
         SpecItemMask('L-1.L999.L', current_version=Version('1.8.3'))
+
 
 def test_specitemmask_yes1():
     s = SpecItemMask('Y.Y.0', current_version=Version('1.8.3'))
@@ -674,7 +676,7 @@ def test_next_best_specitemmask_matching_versions_yes3():
     assert('3.1.2' in subset)
 
 
-def test_next_best_specitemmask_matching_versions_yes3():
+def test_next_best_specitemmask_matching_versions_yes4():
     mask = '-Y.0.0'
     versions = [
         '1.0.0',
@@ -686,7 +688,7 @@ def test_next_best_specitemmask_matching_versions_yes3():
     assert('2.0.1' in subset)
 
 
-def test_next_best_specitemmask_matching_versions_yes4():
+def test_next_best_specitemmask_matching_versions_yes5():
     mask = '-Y.Y.0'
     versions = [
         '1.0.0',
@@ -702,7 +704,7 @@ def test_next_best_specitemmask_matching_versions_yes4():
     assert('2.0.1' in subset)
 
 
-def test_next_best_specitemmask_matching_versions_yes5():
+def test_next_best_specitemmask_matching_versions_yes6():
     mask = '-Y.0.0'
     versions = [
         '1.0.0',
@@ -735,7 +737,7 @@ def test_next_best_example():
     assert VersionFilter.semver_filter('-Y.0.0', versions, current_version) == ['3.0.1']
 
 
-def test_greater_than_current_major():
+def test_greater_than_next_major():
     mask = '>=L1.0.0'
     versions = ['1.0.0', '1.0.1', '1.1.0', '1.2.0', '2.0.0', '2.0.1', '3.0.0']
     current_version = '1.0.0'
@@ -745,3 +747,12 @@ def test_greater_than_current_major():
     assert('2.0.1' in subset)
     assert('3.0.0' in subset)
 
+
+def test_in_next_major():
+    mask = 'L1.Y.Y'
+    versions = ['1.0.0', '1.0.1', '1.1.0', '1.2.0', '2.0.0', '2.0.1', '3.0.0']
+    current_version = '1.0.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(2 == len(subset))
+    assert('2.0.0' in subset)
+    assert('2.0.1' in subset)

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -657,7 +657,7 @@ def test_next_best_specitemmask_matching_versions_yes2():
     assert('3.1.2' in subset)
 
 
-def test_next_best_specitemmask_matching_versions_yes2x():
+def test_next_best_specitemmask_matching_versions_yes3():
     mask = '-Y.0.0'
     versions = [
         '1.0.0',

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -29,6 +29,19 @@ def test_specitemmask_lock3():
     assert(Spec('1.8.3') == s.spec)
 
 
+def test_specitemmask_lock4():
+    s = SpecItemMask('L1.L.L', current_version=Version('1.8.3'))
+    assert(Spec('2.8.3') == s.spec)
+
+
+def test_specitemmask_lock5():
+    s = SpecItemMask('L1.L999.L', current_version=Version('1.8.3'))
+    assert(Spec('2.1007.3') == s.spec)
+
+def test_specitemmask_lock6():
+    with pytest.raises(ValueError):
+        SpecItemMask('L-1.L999.L', current_version=Version('1.8.3'))
+
 def test_specitemmask_yes1():
     s = SpecItemMask('Y.Y.0', current_version=Version('1.8.3'))
     assert(Spec('*') == s.spec)
@@ -122,7 +135,7 @@ def test_partial_versions_3():
     mask = 'L'
     current_version = '1'
     s = SpecItemMask(mask, current_version)
-    assert(s.spec == Spec('==1.0.0'))
+    assert(s.spec == Spec('==1'))
 
 
 def test_partial_versions_4():
@@ -548,7 +561,7 @@ def test_next_best_specitemmask_matching_versions_lock3():
 
 
 def test_get_next_best_versions1():
-    y = YesVersion('Y.0.0')
+    y = YesVersion('*', 'Y.0.0')
     versions = [
         '1.0.0',
         '1.0.1',
@@ -563,7 +576,7 @@ def test_get_next_best_versions1():
 
 
 def test_get_next_best_versions2():
-    y = YesVersion('Y.Y.0')
+    y = YesVersion('*', 'Y.Y.0')
     versions = [
         '1.0.0',
         '1.0.1',
@@ -581,7 +594,7 @@ def test_get_next_best_versions2():
 
 
 def test_get_next_best_versions3():
-    y = YesVersion('1.0.0')
+    y = YesVersion('*', '1.0.0')
     versions = [
         '1.0.0',
         '1.0.1',
@@ -596,7 +609,7 @@ def test_get_next_best_versions3():
 
 
 def test_get_next_best_versions4():
-    y = YesVersion('Y.Y.Y')
+    y = YesVersion('*', 'Y.Y.Y')
     versions = [
         '1.0.0',
         '1.0.1',
@@ -639,7 +652,24 @@ def test_next_best_specitemmask_matching_versions_yes2():
     current_version = '1.0.0'
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(3 == len(subset))
-    assert('1.1.0' in subset)
+    assert('1.1.0' in subset) # Surprising, but it's only here because 1.0.0 (current_version) is not in the list
+    assert('2.0.1' in subset)
+    assert('3.1.2' in subset)
+
+
+def test_next_best_specitemmask_matching_versions_yes2x():
+    mask = '-Y.0.0'
+    versions = [
+        '1.0.0',
+        '1.1.0',
+        '1.2.0',
+        '1.3.0',
+        '2.0.1',
+        '3.1.2',
+    ]
+    current_version = '1.0.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(2 == len(subset))
     assert('2.0.1' in subset)
     assert('3.1.2' in subset)
 
@@ -703,3 +733,15 @@ def test_next_best_example():
     assert VersionFilter.semver_filter('Y.0.0', versions, current_version) == []
     # but with next_best ...
     assert VersionFilter.semver_filter('-Y.0.0', versions, current_version) == ['3.0.1']
+
+
+def test_greater_than_current_major():
+    mask = '>=L1.0.0'
+    versions = ['1.0.0', '1.0.1', '1.1.0', '1.2.0', '2.0.0', '2.0.1', '3.0.0']
+    current_version = '1.0.0'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(3 == len(subset))
+    assert('2.0.0' in subset)
+    assert('2.0.1' in subset)
+    assert('3.0.0' in subset)
+


### PR DESCRIPTION
Addresses the needs in #20 .

The desired behavior of "everything greater than versions sharing my major number" can easily be expressed as a mask `">=L1.0.0"` and can be seen in:

```python
def test_greater_than_current_major():
    mask = '>=L1.0.0'
    versions = ['1.0.0', '1.0.1', '1.1.0', '1.2.0', '2.0.0', '2.0.1', '3.0.0']
    current_version = '1.0.0'
    subset = VersionFilter.semver_filter(mask, versions, current_version)
    assert(3 == len(subset))
    assert('2.0.0' in subset)
    assert('2.0.1' in subset)
    assert('3.0.0' in subset)
```
@Hypnosphi Have I finally gotten something that might work for you?