### PR TITLE
add validation method

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add Semver validation method
 
 
 0.7.0 (2018-01-16)

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -351,7 +351,8 @@ def test_prerelease_matching():
 
 def test_prerelease_matching_2():
     mask = 'L.L.Y-alpine3.6'
-    versions = ['3.6', '3.6-alpine', '3.6-alpine3.6', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6', '3.6.1-onbuild']
+    versions = ['3.6', '3.6-alpine', '3.6-alpine3.6', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6',
+                '3.6.1-onbuild']
     current_version = '3.6-alpine3.6'
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(1 == len(subset))
@@ -369,7 +370,8 @@ def test_prerelease_lock():
 
 def test_prerelease_lock_2():
     mask = 'L.L.Y-L'
-    versions = ['3.6', '3.6-alpine', '3.6-alpine3.6', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6', '3.6.1-onbuild']
+    versions = ['3.6', '3.6-alpine', '3.6-alpine3.6', '3.6-onbuild', '3.6.1', '3.6.1-alpine', '3.6.1-alpine3.6',
+                '3.6.1-onbuild']
     current_version = '3.6-alpine3.6'
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(1 == len(subset))
@@ -654,7 +656,7 @@ def test_next_best_specitemmask_matching_versions_yes2():
     current_version = '1.0.0'
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(3 == len(subset))
-    assert('1.1.0' in subset) # Surprising, but it's only here because 1.0.0 (current_version) is not in the list
+    assert('1.1.0' in subset)  # Surprising, but it's only here because 1.0.0 (current_version) is not in the list
     assert('2.0.1' in subset)
     assert('3.1.2' in subset)
 
@@ -756,3 +758,19 @@ def test_in_next_major():
     assert(2 == len(subset))
     assert('2.0.0' in subset)
     assert('2.0.1' in subset)
+
+
+def test_validate_only():
+    invalid_masks = ['L1.Y.Y', '1.0.0', '1.0.0', '1.0', '1', 'L', 'L.Y', 'L.Y.Y', 'L.Y.Y', 'Y.0.0', 'Y.0.0', 'Y.Y.0',
+                     'L.Y.0', 'Y.Y.Y', '2.0.0', 'Y.Y.Y', '1.8.Y', '1.8.Y || 1.10.Y', 'Y.Y.0 || L.L.Y',
+                     '>1.8.0 && <2.0.0', 'L.Y.Y', 'L.Y.Y-Y', 'L.Y.Y-Y', 'L.Y.Y', 'Y.Y.Y', 'Y.Y.Y-Y', 'L.L.Y-alpine',
+                     'L.L.Y-alpine3.6', 'L.L.Y-L', 'L.L.Y-L', 'L.L.Y', 'L.L.Y', 'L.L.Y', 'L.L.Y', 'L.L.Y', '^1.0.0',
+                     '^L.L.L', '^L.L.L', '-1.0.0', '-1.0.0', '-1.0.0', '-L.0.0', '-L.0.0', '-L.0.0', '-Y.0.0', '-Y.0.0',
+                     '-Y.0.0', '-Y.0.0', '-Y.Y.0', '-Y.0.0', '>=L1.0.0', 'L1.Y.Y', 'L.L.L-L']
+
+    for m in invalid_masks:
+        assert(VersionFilter.semver_validate(m) is True)
+
+    invalid_masks = ['-^1.1.1', 'a', '?.?.?', '', 'YY.0.0', 'LL.0.0']
+    for m in invalid_masks:
+        assert(VersionFilter.semver_validate(m) is False)

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -18,6 +18,15 @@ class VersionFilter(object):
         return specmask.matching_versions(versions)
 
     @staticmethod
+    def semver_validate(mask):
+        """Returns True if the given mask is valid syntactically, False otherwise"""
+        try:
+            specmask = SpecMask(mask, validate_only=True)
+        except (InvalidSemverError, ValueError) as e:
+            return False
+        return True  # all mask exceptions are raised by instantiation
+
+    @staticmethod
     def regex_filter(regex_str, versions):
         """Return a list of versions that match the given regular expression."""
         regex = re.compile(regex_str)
@@ -275,9 +284,13 @@ class SpecMask(object):
     AND = "&&"
     OR = "||"
 
-    def __init__(self, specmask, current_version=None):
+    def __init__(self, specmask, current_version=None, validate_only=False):
         self.speckmask = specmask
+        self.validate_only = validate_only
         self.current_version = current_version
+        if self.validate_only and not current_version:
+            # If we're only validating, we'll make an arbitrary current version to handle masks with LOCKs
+            self.current_version = '1.1.1'
         self.specs = None
         self.op = None
         self.parse(specmask)


### PR DESCRIPTION
@davegaeddert 

What do you think of the `VersionFilter.semver_validate(mask)` method name?  I think the validation needs to be tied just to the semver, not regex, side of the equation, no?

closes #8 
