### PR TITLE
More specific requirements for * usage

### DIFF
--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -14,6 +14,23 @@ def test_specitemmask_asterisk():
     assert(Version('0.1.1-alpha') in s.spec)
 
 
+def test_specitemmask_asterisk_forms():
+    s = SpecItemMask(' *')
+    assert s.kind == '*'
+
+    s = SpecItemMask(' *  ')
+    assert s.kind == '*'
+
+    s = SpecItemMask('*')
+    assert s.kind == '*'
+
+    with pytest.raises(ValueError):
+        SpecItemMask('bad*')
+
+    with pytest.raises(ValueError):
+        SpecItemMask('* bad')
+
+
 def test_specitemmask_lock1():
     s = SpecItemMask('L.0.0', current_version=Version('1.0.0'))
     assert(Spec('1.0.0') == s.spec)

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -191,7 +191,7 @@ class SpecItemMask(object):
             self.has_lock = True
 
             if not self.current_version:
-                raise ValueError('Without a current_version, SpecItemMask objects with LOCKs ' 
+                raise ValueError('Without a current_version, SpecItemMask objects with LOCKs '
                                  'cannot be converted to Specs')
 
             mask_components = SemverComponents.parse(self.version)  # our own parsing attempt
@@ -208,7 +208,7 @@ class SpecItemMask(object):
             self.version = str(mask_components.substitute_lock(self.current_version))
 
     def parse(self, specitemmask):
-        if '*' in specitemmask:
+        if specitemmask.strip() == '*':
             self.kind = '*'
             self.version = ''
             return


### PR DESCRIPTION
I was using the validate function and happened to type in a jibberish test case that had a "*" in it (`'HW:E*'`). I was surprised to see that it said it was a valid mask. Are there any downsides to making this change?