### PR TITLE
Remove all leading v and = chars for cleaned version

### DIFF
--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -397,7 +397,7 @@ def test_prerelease_lock_2():
 
 def test_v_prefix_on_versions():
     mask = 'L.L.Y'
-    versions = ['v0.9.5', '=0.9.6', 'v1.0.0']
+    versions = ['v0.9.5', 'v0.9.6', 'v1.0.0']
     current_version = '0.9.5'
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(1 == len(subset))

--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -397,7 +397,7 @@ def test_prerelease_lock_2():
 
 def test_v_prefix_on_versions():
     mask = 'L.L.Y'
-    versions = ['v0.9.5', 'v0.9.6', 'v1.0.0']
+    versions = ['v0.9.5', '=0.9.6', 'v1.0.0']
     current_version = '0.9.5'
     subset = VersionFilter.semver_filter(mask, versions, current_version)
     assert(1 == len(subset))
@@ -435,8 +435,18 @@ def test_v_and_eq_prefix_on_current_version():
     mask = 'L.L.Y'
     versions = ['0.9.5', '0.9.6', '1.0.0']
     current_version = 'v=0.9.5'
-    with pytest.raises(ValueError):
-        VersionFilter.semver_filter(mask, versions, current_version)
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('0.9.6' in subset)
+    
+    
+def test_eq_and_eq_prefix_on_current_version():
+    mask = 'L.L.Y'
+    versions = ['0.9.5', '0.9.6', '1.0.0']
+    current_version = '==0.9.5'
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(1 == len(subset))
+    assert('0.9.6' in subset)
 
 
 def test_caret():

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -509,7 +509,7 @@ def _parse_semver(version, makefake=False):
         return version
     if isinstance(version, str):
         # strip leading 'v' and '=' chars
-        cleaned = version[1:] if version.startswith('=') or version.startswith('v') else version
+        cleaned = version.lstrip('v=')
         try:
             v = semantic_version.Version(cleaned)
         except ValueError:


### PR DESCRIPTION
This makes it a little more flexible to account for a "==" situation and a "=v" situation.