### PR TITLE
semver_filter sorted results

### DIFF
--- a/tests/test_version_filter.py
+++ b/tests/test_version_filter.py
@@ -496,6 +496,17 @@ def test_semver_caret_with_locks():
     assert('0.3.1' in subset)
 
 
+def test_semver_filter_sorted_return():
+    mask = 'Y.Y.Y'
+    versions = ['0.9.6', '1.0.0', '0.9.5']
+    current_version = None
+    subset = VersionFilter.semver_filter(mask, versions, current_version)
+    assert(3 == len(subset))
+    assert('0.9.5' == subset[0])
+    assert('0.9.6' == subset[1])
+    assert('1.0.0' == subset[2])
+
+
 def test_valid_version_parsing_1():
     assert(Version('0.0.1') == _parse_semver('0.0.1'))
     assert(Version('0.0.1-dev0') == _parse_semver('0.0.1-dev0'))

--- a/version_filter/version_filter.py
+++ b/version_filter/version_filter.py
@@ -343,7 +343,7 @@ class SpecMask(object):
             for v_set in versions_sets:
                 matched_versions = matched_versions.union(v_set)
 
-        return [v.original_string for v in matched_versions]
+        return [v.original_string for v in sorted(matched_versions)]
 
     def __contains__(self, item):
         return self.match(item)


### PR DESCRIPTION
Bit of a coincidence that I realized this, but I think that `semver_filter` used to return the results in a sorted order and it no longer does. @paulortman do you have an opinion on this? I'm thinking that that behavior made sense, and if not as the default then at least as an option. There's no good way to sort the returned results after the fact since they're just strings and not Version objects. I was going to try adding it back in but I'm not sure of the best place to do it.